### PR TITLE
ASM-3115 VM scale up fails on FCoE deployment

### DIFF
--- a/lib/puppet/util/network_device/cisconexus5k/device.rb
+++ b/lib/puppet/util/network_device/cisconexus5k/device.rb
@@ -399,6 +399,10 @@ class Puppet::Util::NetworkDevice::Cisconexus5k::Device < Puppet::Util::NetworkD
         Puppet.info("A switch interface with a native VLAN is being configured.")
         Puppet.debug("Command: 'switchport trunk native vlan #{nativevlanid}'")
         execute("switchport trunk native vlan #{nativevlanid}")
+      elsif isnative == "false"
+        Puppet.info("Need to remove the vative vlan configuration.")
+        Puppet.debug("Command: 'no switchport trunk native vlan #{nativevlanid}'")
+        execute("no switchport trunk native vlan #{nativevlanid}")
       end
       execute("switchport trunk allowed vlan add #{id}")
       execute("no shutdown")


### PR DESCRIPTION
Added changes to remove the native vlan configuration. This is required for FCOE deployments where PXE VLAN needs to be tagged once deployment is completed