### PR TITLE
ASM-3406 remove asm_decrypt password encryption

### DIFF
--- a/lib/puppet/util/network_device/base_nxos.rb
+++ b/lib/puppet/util/network_device/base_nxos.rb
@@ -2,8 +2,6 @@ require 'puppet/util/autoload'
 require 'uri'
 require 'puppet/util/network_device/transport'
 require 'puppet/util/network_device/transport/base'
-require '/etc/puppetlabs/puppet/modules/asm_lib/lib/security/encode'
-
 
 class Puppet::Util::NetworkDevice::Base_nxos
 

--- a/lib/puppet/util/network_device/cisconexus5k/device.rb
+++ b/lib/puppet/util/network_device/cisconexus5k/device.rb
@@ -3,7 +3,6 @@ require 'puppet'
 require 'puppet/util'
 require 'puppet/util/network_device/base_nxos'
 require 'puppet/util/network_device/cisconexus5k/facts'
-require '/etc/puppetlabs/puppet/modules/asm_lib/lib/security/encode'
 
 #
 # Main device class for Cisco nexus5k module
@@ -67,7 +66,7 @@ class Puppet::Util::NetworkDevice::Cisconexus5k::Device < Puppet::Util::NetworkD
       password = cred.password
     else
       user = @url.user
-      password = URI.decode(asm_decrypt(@url.password))
+      password = URI.decode(@url.password)
     end
 
     if user != ''


### PR DESCRIPTION
An encrypted device password was passed to the asm-deployer device
management service and written to the device configuration file
url. That password has been deprecated and all puppet-layer code
should use the credential_id argument in preference to that.

Additionally the credential-id argument will no longer be passed to
inventory scripts since it is redundant -- the information contained
in it is already passed as separate plaintext arguments.