### PR TITLE
ASM-4806 Discovery Logging

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -18,6 +18,27 @@ opts = Trollop::options do
   opt :password, 'switch password', :type => :string, :default => ENV['PASSWORD']
   opt :timeout, 'command timeout', :default => 240
   opt :community_string, 'dummy value for ASM, not used'
+  opt :output, 'output facts to a file', :type => :string, :required => true
+end
+
+begin
+  args=['--trace']
+
+  Puppet.settings.initialize_global_settings(args)
+  Puppet.settings.initialize_app_defaults(Puppet::Settings.app_defaults_for_run_mode(Puppet.run_mode))
+  if Puppet.respond_to?(:base_context) && Puppet.respond_to?(:push_context)
+    Puppet.push_context(Puppet.base_context(Puppet.settings))
+  end
+
+  Puppet::Util::Log.newdestination("console")
+  Puppet::Util::Log.level = :debug
+
+  Puppet[:color] = false
+
+  Puppet.debug('Puppet logging set to console')
+rescue
+  puts 'Error setting up console logging'
+  exit 1
 end
 
 begin
@@ -44,7 +65,6 @@ else
     facts.each do |fact, value|
       facts[fact] = value.to_s
     end
-    puts facts.to_json
-    exit 0
+    File.write(opts[:output], facts.to_json)
   end
 end


### PR DESCRIPTION
Add the --output argument to the discovery script which specifies where to write the device facts.
Change the Puppet logger to print to the console so we can capture the output for debugging