### PR TITLE
ASM-5063 FCoE Deployment with Cisco Nexus failing intermittently due to missing discovery facts

### DIFF
--- a/lib/puppet_x/cisconexus5k/facts.rb
+++ b/lib/puppet_x/cisconexus5k/facts.rb
@@ -126,7 +126,7 @@ class PuppetX::Cisconexus5k::Facts
     if ( out =~ /NAME:\s+"Chassis",\s+DESCR:.*\n.*SN:\s+(\S+)/ )
       facts[:chassisserialnumber] = $1
     end
-    
+
     # Get FLOGI information
     out = @transport.command("show flogi database")
     flogi_info = []
@@ -154,6 +154,9 @@ class PuppetX::Cisconexus5k::Facts
     vsan_zoneset_info = []
     out = @transport.command('show zoneset active')
     vsan_zoneset_info = out.scan(/^zoneset\s+name\s*(\S+)\s+vsan\s+(\d+)/)
+
+    # Adding show version command to clear the buffer prompts
+    out = @transport.command("show version")
     
     # Remote LLDP information from the switch
     lldp_info = []

--- a/lib/puppet_x/cisconexus5k/ssh.rb
+++ b/lib/puppet_x/cisconexus5k/ssh.rb
@@ -8,7 +8,7 @@ module PuppetX
       #These switches require a carriage return as well, instead of just new line.  So we override Puppet's method to add \r
       def send(line, noop=false)
         Puppet.debug "SSH send: #{line}" if Puppet[:Debug]
-        @channel.send_data(line + "\n\r") unless noop
+        @channel.send_data(line + "\r") unless noop
       end
 
       def sendwithoutnewline(line, noop = false)


### PR DESCRIPTION
Extra "\n" was added to the SSH Send block leading to an extra prompt in the command output. As a result if any command is sending blank output then the next command output was getting appended with extra prompts.

Also added command "show version" after commands sending blank output so that further command outputs are not affected