### PR TITLE
ASM-5116 remote_device_info switch fact as Array

### DIFF
--- a/lib/puppet_x/cisconexus5k/facts.rb
+++ b/lib/puppet_x/cisconexus5k/facts.rb
@@ -162,11 +162,11 @@ class PuppetX::Cisconexus5k::Facts
     lldp_info = []
     out = @transport.command('show lldp  neighbors')
     lldp_info = out.scan(/^([a-f0-9\.]+)\s+(\S+)/m)
-    remote_device_info = {}
+    remote_device_info = []
     if !lldp_info.empty?
       lldp_info.each do |lldp_entry|
         remote_device = { :interface => lldp_entry[1].strip, :remote_mac => lldp_entry[0].strip}
-        remote_device_info[remote_device[:interface]] = remote_device
+        remote_device_info << remote_device
       end
     end
     


### PR DESCRIPTION
Change this fact to be a list of hashes.
From:
` { “interface name” => { :interface, :location, :remote_mac } } `
To:
`[ {:interface, :location, :remote_mac } ]`

example output:  https://gist.github.com/logankimmel/e6f2e553a2be2e4b096e