### PR TITLE
ASM-8827 Puppet4 compliance

### DIFF
--- a/lib/puppet/util/network_device/base_nxos.rb
+++ b/lib/puppet/util/network_device/base_nxos.rb
@@ -13,8 +13,7 @@ class Puppet::Util::NetworkDevice::Base_nxos
 
     @autoloader = Puppet::Util::Autoload.new(
     self,
-    "puppet/util/network_device/transport",
-    :wrap => false
+    "puppet/util/network_device/transport"
     )
 
     if @autoloader.load(@url.scheme)

--- a/spec/fixtures/modules/cisconexus5k/lib/puppet/util/network_device/base_nxos.rb
+++ b/spec/fixtures/modules/cisconexus5k/lib/puppet/util/network_device/base_nxos.rb
@@ -12,8 +12,7 @@ class Puppet::Util::NetworkDevice::Base_nxos
 
     @autoloader = Puppet::Util::Autoload.new(
       self,
-      "puppet/util/network_device/transport",
-      :wrap => false
+      "puppet/util/network_device/transport"
     )
 
     if @autoloader.load(@url.scheme)


### PR DESCRIPTION
The :wrap parameter is not valid for puppet 4. I've tested this
to make sure the module still works on the old puppet wth discovery
and basic deployment.

Because a lot of this code was copy-pasted, I have a feeling this
was nevery needed (especially because it's set to false)