### PR TITLE
VXFM-2849 Removes spanning tree mode in access ports.

### DIFF
--- a/lib/puppet_x/cisconexus5k/transport.rb
+++ b/lib/puppet_x/cisconexus5k/transport.rb
@@ -503,7 +503,7 @@ class PuppetX::Cisconexus5k::Transport
         Puppet.info "removing port channel."
         execute("no channel-group")
         Puppet.info "removing spanning tree."
-        execute("no spanning-tree port type")
+        execute("no spanning-tree port type edge trunk")
         execute("no mtu")
         if resource[:shutdownswitchinterface] == "true" && resource[:unconfiguretrunkmode] == "false"
           Puppet.info "The interface #{interface_id} is being shut down."
@@ -648,7 +648,7 @@ class PuppetX::Cisconexus5k::Transport
         execute("no switchport trunk allowed vlan")
 
         Puppet.info("spanning tree config is being removed")
-        execute("no spanning-tree port type")
+        execute("no spanning-tree port type edge trunk")
       end
 
       if resource[:deletenativevlaninformation] == "true"


### PR DESCRIPTION
The present command we use to remove spanning tree only works on certain
nexus models. This PR uses complete command to remove spanning tree and
supports all vxfm supported nexus models.