### PR TITLE
VXFM-3766 Aligns with interface speed while setting port-channel speed

### DIFF
--- a/lib/puppet_x/cisconexus5k/transport.rb
+++ b/lib/puppet_x/cisconexus5k/transport.rb
@@ -1116,7 +1116,7 @@ class PuppetX::Cisconexus5k::Transport
 
       if should[:speed]
         expected_interface_port_info = parse_interfaces(should[:interface_port])
-        existing_port_speed = expected_interface_port_info[:speed]
+        existing_port_speed = expected_interface_port_info[should[:interface_port]][:speed]
 
         existing_port_speed ? execute("speed #{existing_port_speed}") : execute("speed #{should[:speed]}")
       end

--- a/spec/unit/puppet_x/cisconexus5k/transport_spec.rb
+++ b/spec/unit/puppet_x/cisconexus5k/transport_spec.rb
@@ -34,6 +34,7 @@ describe PuppetX::Cisconexus5k::Transport do
               :untagged_vlan => "1", :tagged_vlan => "99,17",
               :mtu => "9216",:interface_port =>"Eth1/5", :speed => "10000", :istrunkforportchannel => "true", :removeallassociatedvlans => "true"}
     is = {:name => "200", :protocol => "NONE", :interfaces => "Eth1/5(D)    ", :speed => nil}
+    interface_config = {"Eth1/5" => {:name => "200", :protocol => "NONE", :interfaces => "Eth1/5(D)    ", :speed => nil}}
 
     before(:each) do
       expect(transport).to receive(:execute).with("conf t")
@@ -46,7 +47,7 @@ describe PuppetX::Cisconexus5k::Transport do
       expect(transport).to receive(:execute).with("speed 10000")
       expect(transport).to receive(:execute).with("mtu 9216")
       expect(transport).to receive(:execute).with("no shutdown")
-      expect(transport).to receive(:parse_interfaces).and_return(is)
+      expect(transport).to receive(:parse_interfaces).and_return(interface_config)
       expect(transport).not_to receive(:execute).with("switchport mode access")
 
       transport.update_port_channel("17,19", "20", {}, is, should, "200", "true", {}, "present")


### PR DESCRIPTION
Currently VXFM skips setting interface port speed if it is already exists
leaving port with old speed. port-channel will be configured with
new speed making mismatch with interface port.

This PR will set interface's speed to a port-channel if present