### PR TITLE
VXFM-5115: Removing update_interface call as it is not required for firmware update

### DIFF
--- a/lib/puppet/provider/cisconexus5k_firmwareupdate/cisco.rb
+++ b/lib/puppet/provider/cisconexus5k_firmwareupdate/cisco.rb
@@ -160,13 +160,6 @@ Puppet::Type.type(:cisconexus5k_firmwareupdate).provide :cisconexus5k, :parent =
 
 
   def flush
-    transport.command do |dev|
-    interface = resource[:name]
-    # native vlans can be used only on truck mode.
-    is_native = resource[:istrunkforinterface]
-
-    dev.update_interface(resource, former_properties, properties, interface, is_native)
-    end
-    super
+    Puppet.debug("in firmwareupdate flush method")
   end
 end


### PR DESCRIPTION
The update_interface() call is not required in case of firmware update. In fact, it is not being called as the **resource[:istrunkforinterface]** is causing an error because there are no parameters in resource except for the name.