### PR TITLE
VXFM-5277 Code optimization for CISCO puppet run

### DIFF
--- a/lib/puppet/provider/cisconexus5k.rb
+++ b/lib/puppet/provider/cisconexus5k.rb
@@ -14,6 +14,8 @@ class Puppet::Provider::Cisconexus5k < Puppet::Provider::NetworkDevice
   end
 
   def self.prefetch(resources)
+    transport.connect
+
     resources.each do |name, resource|
       current = get_current(name)
       #We want to pass the transport through so we don't keep initializing new ssh connections for every single resource
@@ -22,6 +24,13 @@ class Puppet::Provider::Cisconexus5k < Puppet::Provider::NetworkDevice
       else
         resource.provider = new({:ensure => :absent}, transport)
       end
+    end
+  end
+
+  def self.post_resource_eval()
+    # closes existing session if exists
+    if @transport.session.channel
+      @transport.disconnect
     end
   end
 end

--- a/lib/puppet/provider/cisconexus5k_vlan/cisco.rb
+++ b/lib/puppet/provider/cisconexus5k_vlan/cisco.rb
@@ -21,6 +21,12 @@ Puppet::Type.type(:cisconexus5k_vlan).provide :cisconexus5k, :parent => Puppet::
     end
     super
   end
+
+  def self.post_resource_eval()
+    Puppet.info "Saving running-config to start-up config"
+    @transport.execute("copy running-config startup-config")
+    super()
+  end
 end
 
 

--- a/lib/puppet/type/cisconexus5k_interface.rb
+++ b/lib/puppet/type/cisconexus5k_interface.rb
@@ -193,11 +193,4 @@ Puppet::Type.newtype(:cisconexus5k_interface) do
       end
     end
   end
-
-  newproperty(:save_start_up_config) do
-    desc "saves running-config to startup config"
-    validate do |value|
-      return unless value
-    end
-  end
 end

--- a/lib/puppet/type/vlan.rb
+++ b/lib/puppet/type/vlan.rb
@@ -203,9 +203,4 @@ Puppet::Type.newtype(:vlan) do
       value.to_s
     end
   end
-
-  newproperty(:save_start_up_config) do
-    desc "saves running-config to startup config"
-    defaultto "true"
-    end
 end

--- a/lib/puppet_x/cisconexus5k/transport.rb
+++ b/lib/puppet_x/cisconexus5k/transport.rb
@@ -46,7 +46,6 @@ class PuppetX::Cisconexus5k::Transport
     @enable_password = device_conf[:password]
     #options[:enable_password] || parse_enable(device_conf[:password])
     @session.default_prompt = /\r.*[#>]\s?\z/n
-
   end
 
   #def credential
@@ -104,10 +103,10 @@ class PuppetX::Cisconexus5k::Transport
   end
 
   def command(cmd = nil)
-    connect
+    connect unless session.channel
     out = execute(cmd) if cmd
     yield self if block_given?
-    disconnect
+
     out
   end
 
@@ -450,9 +449,6 @@ class PuppetX::Cisconexus5k::Transport
     end
 
     execute("exit")
-
-    Puppet.info "Saving running-config to start-up config"
-    execute("copy running-config startup-config")
   end
 
   def update_interface(resource, is = {}, should = {}, interface_id = {}, is_native = {})
@@ -529,11 +525,6 @@ class PuppetX::Cisconexus5k::Transport
       execute("exit")
     else
       configure_interface_port(resource, is, should, interface_id, is_native, native_vlan_id)
-    end
-
-    if resource[:save_start_up_config] && resource[:save_start_up_config] == "true"
-      Puppet.info "Saving running-config to start-up config"
-      execute("copy running-config startup-config")
     end
   end
 

--- a/spec/unit/puppet_x/cisconexus5k/transport_spec.rb
+++ b/spec/unit/puppet_x/cisconexus5k/transport_spec.rb
@@ -259,21 +259,6 @@ describe PuppetX::Cisconexus5k::Transport do
 
       transport.update_interface(resource, is_resource, should, "Eth1/5", "true")
     end
-
-    it "should copy running config when save_start_up_config is true and ensure absent" do
-      resource = {:name => "Eth1/5", :enforce_portchannel => "false", :port_channel => "200", :tagged_general_vlans => "17", :ensure => :absent,
-                  :istrunkforinterface => "false", :save_start_up_config => "true", :removeallassociatedvlans => "true"}
-      is_resource = {}
-      expect(transport).to receive(:execute).with("show interface Eth1/5")
-      expect(transport).to receive(:execute).with("conf t")
-      expect(transport).to receive(:execute).with("interface Eth1/5")
-      expect(transport).to receive(:execute).with("no description")
-      expect(transport).to receive(:un_configure_access_port)
-      expect(transport).to receive(:execute).with("exit").twice
-
-      expect(transport).to receive(:execute).with("copy running-config startup-config")
-      transport.update_interface(resource, is_resource, should, "Eth1/5", "true")
-    end
   end
 
   describe "#update_tagged_vlans" do


### PR DESCRIPTION
Previously, Cisco puppet run saves switch config on every VLAN resource
and creates a connection on every resource resulting in more than 30 ssh
connections. This made puppet config slower.

This PR will save the switch config during post_resource_eval which runs
at the end of vlan resource type saving only once for each run and also
creates one connection for every resource type resulting 3 ssh sessions
for service deployment.