### PR TITLE
VXFM-5852 - Use HTTP for transfer - Cisco Switch Firmware Update

### DIFF
--- a/lib/puppet/provider/cisconexus5k_firmwareupdate/cisco.rb
+++ b/lib/puppet/provider/cisconexus5k_firmwareupdate/cisco.rb
@@ -23,10 +23,10 @@ Puppet::Type.type(:cisconexus5k_firmwareupdate).provide :cisconexus5k, :parent =
     end
   end
 
-  def run(url, force, copy_to_tftp=nil, path=nil)
+  def run(url, force, copy_to_http=nil, path=nil)
     Puppet.debug("cisconexus5k Puppet::Cisco_Nexus_firmwareUpdate*********************")
-    if copy_to_tftp
-      move_to_tftp(copy_to_tftp,path)
+    if copy_to_http
+      move_to_http(copy_to_http,path)
     end
 
     responsetxt ="firmware update failed"
@@ -141,21 +141,21 @@ Puppet::Type.type(:cisconexus5k_firmwareupdate).provide :cisconexus5k, :parent =
     return true
   end
 
-  def move_to_tftp(copy_to_tftp, path)
+  def move_to_http(copy_to_http, path)
     Puppet.debug("Path::"+path)
-    Puppet.debug("Copying files to TFTP share")
-    tftp_share = copy_to_tftp[0]
-    tftp_path = copy_to_tftp[1]
+    Puppet.debug("Copying files to HTTP share")
+    http_share = copy_to_http[0]
+    http_path = copy_to_http[1]
 
-    full_tftp_path = tftp_share + "/" + tftp_path
-    Puppet.debug("full_tftp_path  --> "+full_tftp_path)
-    tftp_dir = full_tftp_path.split('/')[0..-2].join('/')
-    Puppet.debug("tftp_dir --> "+tftp_dir)
-    if !File.exist? tftp_dir
-      FileUtils.mkdir_p tftp_dir
+    full_http_path = http_share + "/" + http_path
+    Puppet.debug("full_http_path  --> "+full_http_path)
+    http_dir = full_http_path.split('/')[0..-2].join('/')
+    Puppet.debug("http_dir --> "+http_dir)
+    if !File.exist? http_dir
+      FileUtils.mkdir_p http_dir
     end
-    FileUtils.cp path, full_tftp_path
-    FileUtils.chmod_R 0755, tftp_dir
+    FileUtils.cp path, full_http_path
+    FileUtils.chmod_R 0755, http_dir
   end
 
 

--- a/lib/puppet/type/cisconexus5k_firmwareupdate.rb
+++ b/lib/puppet/type/cisconexus5k_firmwareupdate.rb
@@ -13,12 +13,12 @@ Puppet::Type.newtype(:cisconexus5k_firmwareupdate) do
     defaultto :false
   end
 
-  newparam(:copy_to_tftp) do
-    "2 element array, ['path to tftp share','path under tftp share']\nFor example: ['/var/lib/tftpshare','catalog1/firmware.bin']\n***Requires path param"
+  newparam(:copy_to_http) do
+    "2 element array, ['path to http share','path under http share']\nFor example: ['/var/lib/razor/repo-store/firmware','catalog1/firmware.bin']\n***Requires path param"
   end
 
   newparam(:path) do
-    "The original firmware location path.  This has to be used in conjuction with to copy_to_tftp param"
+    "The original firmware location path.  This has to be used in conjuction with to copy_to_http param"
   end
 
   newproperty(:url) do
@@ -50,10 +50,10 @@ Puppet::Type.newtype(:cisconexus5k_firmwareupdate) do
 
     def sync
       event = :executed_command
-      self.resource[:copy_to_tftp] ? copy_to_tftp = self.resource[:copy_to_tftp] : nil
+      self.resource[:copy_to_http] ? copy_to_http = self.resource[:copy_to_http] : nil
       self.resource[:path] ? path = self.resource[:path] : nil
-      Puppet.debug("cisco copy_to_tftp value: #{copy_to_tftp} new path is : #{path}")
-      out = provider.run(self.resource[:url], self.resource[:force], copy_to_tftp, path)
+      Puppet.debug("cisco copy_to_http value: #{copy_to_http} new path is : #{path}")
+      out = provider.run(self.resource[:url], self.resource[:force], copy_to_http, path)
       event
     end
   end


### PR DESCRIPTION
Facing lots of timeout during Cisco Switch update due to TFTP transfer, changes to use HTTP for transferring cisco switch firmware binaries

**Dependent on https://github.com/dell-asm/asm/pull/394**