### PR TITLE
[misc] Fix unit tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
-sudo: false
 script: "bundle exec rake"
+dist: precise
 rvm:
   - 1.9.3
 before_install:


### PR DESCRIPTION
- The `sudo` flag is deprecated

- The default `dist` xenial does not seem to be able to download ruby
  1.9.3 Switch to using the older precise dist for now. Need to
  migrate scripts to ruby 2.x soon.
